### PR TITLE
Migrated to new Mapbox API

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,12 +63,15 @@
 
 		var map = L.map('map').setView([47.2, 19.2], 8);
 
-		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibXJnYW5uIiwiYSI6InJYYzl1SUUifQ.haibkYvobTKkVUksezsT9Q', {
+		L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
 			maxZoom: 18,
+			tileSize: 512,
+			zoomOffset: -1,
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'mapbox.light'
+			id: 'mapbox/light-v10',
+			accessToken: 'pk.eyJ1IjoibXJnYW5uIiwiYSI6InJYYzl1SUUifQ.haibkYvobTKkVUksezsT9Q'
 		}).addTo(map);
 
 


### PR DESCRIPTION
Hi,
The old Mapbox static tiles API no longer works.
For more details: <https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/#leaflet-implementations>